### PR TITLE
Fix: Add scene activation command for H617C effect support

### DIFF
--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -205,12 +205,22 @@ class GoveeBluetoothLight(LightEntity):
                 _LOGGER.debug("Sending effect scenceParam length: %d", len(specialEffect.get('scenceParam', '')))
 
                 try:
+                    # Step 1: Send effect data packets
                     await GoveeBLE.send_multi_packet(self._client, 0xa3,
                         array.array('B', [0x02]),
                         array.array('B', base64.b64decode(specialEffect['scenceParam'])))
-                    _LOGGER.debug("Effect %r sent successfully, sending power-on", effect)
+
+                    # Step 2: Send scene activation command
+                    # The Govee app sends both the 0xa3 effect data AND a
+                    # 0x33 0x05 [mode] [scene_code] activation command.
+                    # Without this, devices like the H617C load the data
+                    # but never activate the effect.
+                    scene_code = scene.get('sceneCode', sceneIndex)
+                    await GoveeBLE.send_single_packet(self._client, GoveeBLE.LEDCommand.COLOR,
+                        [GoveeBLE.LEDMode.SCENES, scene_code & 0xFF, (scene_code >> 8) & 0xFF])
+                    _LOGGER.debug("Effect %r sent with scene activation (code=%d)", effect, scene_code)
+
                     self._current_effect = effect
-                    # Power-on after effect data so the device activates with the effect already loaded
                     await GoveeBLE.send_single_packet(self._client, GoveeBLE.LEDCommand.POWER, [0x1])
                 except Exception as err:
                     _LOGGER.error("Failed to send effect %r: %s", effect, err)


### PR DESCRIPTION
## Summary

- Adds the missing scene activation command (`0x33 0x05 [mode] [scene_code]`) after sending effect data packets
- Without this, devices like the H617C load the effect data but never activate it

## Root Cause

The Govee Android app sends two steps when activating a scene:
1. `0xa3` multi-packet effect data (the integration already does this)
2. `0x33 0x05 0x04 [scene_code]` scene activation command (**missing**)

Captured via Android BT HCI snoop log comparing Govee app traffic against the integration.

## Changes

In `light.py` `async_turn_on()`, after `send_multi_packet()` for effect data, added:

```python
scene_code = scene.get('sceneCode', sceneIndex)
await GoveeBLE.send_single_packet(self._client, GoveeBLE.LEDCommand.COLOR,
    [GoveeBLE.LEDMode.SCENES, scene_code & 0xFF, (scene_code >> 8) & 0xFF])
```

## Testing

Tested on Govee H617C via ESP32-S3 Bluetooth proxy:
- Festival - Disco - A ✅
- Festival - Christmas - A ✅
- Natural - Fire - B ✅
- Festival - Fireworks ✅ (via HA voice assistant)

Fixes #11