### PR TITLE
Add Govee H6178 support

### DIFF
--- a/custom_components/govee-ble-lights/govee_ble.py
+++ b/custom_components/govee-ble-lights/govee_ble.py
@@ -72,17 +72,24 @@ class GoveeBLE:
 
         Different modes tell the device how to interpret the color data:
 
-        MANUAL (0x02) - Direct RGB values for standard strips
-        MICROPHONE (0x06) - Microphone-controlled effects (not implemented)
-        SCENES (0x05) - Scene/effect playback
-        SEGMENTS (0x15) - Segment-specific color control
-
-        Note: Only MANUAL mode is fully supported for color changes.
+        MANUAL (0x02)       - Direct RGB values for standard strips (H6172/H6173).
+        SCENE_ACTIVATE (0x04) - Activate a previously streamed scene blob;
+                                payload is [scene_id]. Paired with the 0xA3
+                                multi-packet write that loaded the scene.
+        SCENES (0x05)       - Built-in scene/effect playback.
+        MICROPHONE (0x06)   - Microphone-controlled effects (not implemented).
+        MANUAL_RGBIC (0x0D) - Solid-color set for RGBIC strips like H6178.
+                              Same payload layout as MANUAL (R,G,B) but a
+                              different mode byte. H6178 firmware silently
+                              ignores writes that use MANUAL or SEGMENTS.
+        SEGMENTS (0x15)     - Segment-specific color control for H617A family.
         """
 
         MANUAL = 0x02
-        MICROPHONE = 0x06
+        SCENE_ACTIVATE = 0x04
         SCENES = 0x05
+        MICROPHONE = 0x06
+        MANUAL_RGBIC = 0x0D
         SEGMENTS = 0x15
 
     class LEDFrameType(IntEnum):
@@ -122,8 +129,24 @@ class GoveeBLE:
         "H618C",
     ]
 
-    # Models that expect brightness as percentage (0-100) instead of 0-255
-    BLE_PERCENT_MODELS = ["H6199", "H617A", "H617C", "H618C"]
+    # Models that expect brightness as percentage (0-100) instead of 0-255.
+    # H6178 confirmed by btsnoop capture: official app sends 0x19/0x32/0x4b/0x64
+    # for the 25/50/75/100 percent slider positions.
+    BLE_PERCENT_MODELS = ["H6199", "H617A", "H617C", "H618C", "H6178"]
+
+    # RGBIC families (each LED individually addressable) that use color mode
+    # 0x0D for solid-color writes instead of MANUAL (0x02) or SEGMENTS (0x15).
+    # These devices silently ACK frames in either of the other two modes but
+    # never apply them; only mode 0x0D actually drives the LEDs.
+    #
+    # Color query layout for this family is also distinct: the request must be
+    # 0xAA 0x05 [0x01] (i.e. ask for segment 1) and the reply is
+    # 0xAA 0x05 0x0D R G B ... -- the existing COLOR notification parser then
+    # reads payload[1..3] as RGB, no separate notification handling needed.
+    #
+    # Orthogonal to BLE_PERCENT_MODELS: a model can be RGBIC and percent
+    # (H6178), RGBIC and raw, segmented and percent, etc.
+    BLE_RGBIC_MODELS = ["H6178"]
 
     # BLE connection and packet timing parameters
     BLE_KEEPALIVE_INTERVAL = 1.0  # Seconds between keepalive packets

--- a/custom_components/govee-ble-lights/jsons/H6178.json
+++ b/custom_components/govee-ble-lights/jsons/H6178.json
@@ -1,0 +1,8 @@
+{
+    "message": "success",
+    "status": 200,
+    "data": {
+        "categories": [],
+        "supportSpeed": 0
+    }
+}

--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -148,6 +148,11 @@ class GoveeBluetoothLight(LightEntity):
         self._model = config_entry.data["model"]
         self._is_segmented = self._model in GoveeBLE.BLE_SEGMENTED_MODELS
         self._use_percent = self._model in GoveeBLE.BLE_PERCENT_MODELS
+        # RGBIC families (H6178) use a dedicated color mode byte 0x0D and a
+        # different color-query payload from both the legacy MANUAL and
+        # SEGMENTS families. They take precedence over _is_segmented in the
+        # color write/query dispatch below.
+        self._is_rgbic = self._model in GoveeBLE.BLE_RGBIC_MODELS
         self._ble_device = ble_device
         self._brightness = 255
         self._state = False
@@ -428,7 +433,18 @@ class GoveeBluetoothLight(LightEntity):
         if ATTR_RGB_COLOR in kwargs:
             red, green, blue = kwargs.get(ATTR_RGB_COLOR)
 
-            if self._is_segmented:
+            if self._is_rgbic:
+                # H6178-style RGBIC: 33 05 0D R G B + zero pad + XOR.
+                # Reverse-engineered from an Android btsnoop_hci.log capture
+                # of the official Govee Home app; identical mode and payload
+                # for every solid-color selection. Neither MANUAL (0x02) nor
+                # SEGMENTS (0x15) drives the LEDs on this firmware.
+                await GoveeBLE.send_single_packet(
+                    self._client,
+                    GoveeBLE.LEDCommand.COLOR,
+                    [GoveeBLE.LEDMode.MANUAL_RGBIC, red, green, blue],
+                )
+            elif self._is_segmented:
                 # Send segment-specific color command
                 await GoveeBLE.send_single_packet(
                     self._client,
@@ -719,7 +735,19 @@ class GoveeBluetoothLight(LightEntity):
             await asyncio.sleep(0.05)
 
             # Request color based on device type
-            if self._is_segmented:  # Request color of device
+            if self._is_rgbic:
+                # H6178: AA 05 01 ... -> reply AA 05 0D R G B ...
+                # The 0x01 in the request body means "report segment 1's color";
+                # an empty payload returns only the overall mode byte (which is
+                # 0x15 for the current firmware regardless of the displayed
+                # color, so it isn't useful for syncing RGB).
+                await GoveeBLE.send_single_packet(
+                    self._client,
+                    GoveeBLE.LEDCommand.COLOR,
+                    [0x01],
+                    GoveeBLE.LEDFrameType.REQUEST,
+                )
+            elif self._is_segmented:  # Request color of device
                 # Segmented device uses SEGMENT command for color request
                 await GoveeBLE.send_single_packet(
                     self._client,


### PR DESCRIPTION
Hi,

I just reverse-engineered my H6178 light with the help of Claude. Tested in my own HA successfully.

## Some Details
H6178 uses Bluetooth control and **RGBIC** color frame 33 05 0D R G B (not MANUAL 0x02 or SEGMENTS 0x15) and percent-byte brightness (33 04 <0-100>). Reverse-engineered from a btsnoop capture of the official Govee Home app on firmware 2.01.13 and confirmed against the lamp.

Also added an extra identified mode `SCENE_ACTIVATE`,  when a `scene` is activated in Govee Home app.

## Touched Files
- govee_ble.py: add LEDMode.MANUAL_RGBIC (0x0D) and SCENE_ACTIVATE (0x04); add BLE_MODE_RGBIC_MODELS; add H6178 to BLE_RGBIC_MODELS.
- light.py: route color writes through 33 05 0D R G B for these models, and request color state via aa 05 01 (which returns aa 05 0D R G B, parsed correctly by the existing notification handler).
- jsons/H6178.json: stub for the config_flow dropdown.

## TODOs
- Scenes/effects are deferred -- needs more App captures per scene. Only added the `SCENES (0x05)` mode placeholder.


Let me know what I might still need to do before the merge :)