### PR TITLE
Add `H617E` to the list of segmented models

### DIFF
--- a/custom_components/govee-ble-lights/govee_ble.py
+++ b/custom_components/govee-ble-lights/govee_ble.py
@@ -119,6 +119,7 @@ class GoveeBLE:
         "H6199",
         "H617A",
         "H617C",
+        "H617E",
         "H618C",
     ]
 


### PR DESCRIPTION
Hey :)

Thanks for your work. Unfortunately the `H617E` did use the wrong commands, ergo was not able to e.g. change colors.

This small CR fixes that problem :)